### PR TITLE
debouncedEffect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ng-signal-utils",
       "version": "0.0.0",
+      "license": "MIT",
       "dependencies": {
         "@angular/common": "^19.2.0",
         "@angular/compiler": "^19.2.0",
@@ -15,6 +16,7 @@
         "@angular/platform-browser": "^19.2.0",
         "@angular/platform-browser-dynamic": "^19.2.0",
         "@angular/router": "^19.2.0",
+        "lodash.debounce": "^4.0.8",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -24,6 +26,7 @@
         "@angular/cli": "^19.2.4",
         "@angular/compiler-cli": "^19.2.0",
         "@types/jasmine": "~5.1.0",
+        "@types/lodash.debounce": "^4.0.9",
         "jasmine-core": "~5.6.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",
@@ -4939,6 +4942,21 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
+      "dev": true
+    },
+    "node_modules/@types/lodash.debounce": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.9.tgz",
+      "integrity": "sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -9207,8 +9225,7 @@
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-      "dev": true
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "type": "git",
     "url": "https://github.com/adamsheaffer/ng-signal-utils.git"
   },
-  "keywords": ["angular", "ng", "signals"],
+  "keywords": [
+    "angular",
+    "ng",
+    "signals"
+  ],
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,6 +30,7 @@
     "@angular/platform-browser": "^19.2.0",
     "@angular/platform-browser-dynamic": "^19.2.0",
     "@angular/router": "^19.2.0",
+    "lodash.debounce": "^4.0.8",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"
@@ -35,6 +40,7 @@
     "@angular/cli": "^19.2.4",
     "@angular/compiler-cli": "^19.2.0",
     "@types/jasmine": "~5.1.0",
+    "@types/lodash.debounce": "^4.0.9",
     "jasmine-core": "~5.6.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",

--- a/projects/ng-signal-utils/src/lib/debounced-effect/debounced-effect.spec.ts
+++ b/projects/ng-signal-utils/src/lib/debounced-effect/debounced-effect.spec.ts
@@ -1,0 +1,68 @@
+import { DestroyRef, Injector, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { withInjectionContext } from '../../utils/testing/withInjectionContext';
+import { debouncedEffect as sutOriginal } from './';
+
+describe('debouncedEffect', () => {
+  let debouncedEffect: typeof sutOriginal;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [DestroyRef],
+    });
+    const testInjector = TestBed.inject(Injector);
+
+    debouncedEffect = withInjectionContext(testInjector, sutOriginal);
+
+    jasmine.clock().install();
+    jasmine.clock().mockDate(new Date());
+  });
+
+  afterEach(() => jasmine.clock().uninstall());
+
+  it('should debounce effect calls', () => {
+    const query = signal('');
+    const searchSpy = jasmine
+      .createSpy('searchSpy')
+      .and.callFake(() => `Running search with ${query()}`);
+
+    debouncedEffect(() => searchSpy() && console.log(query()), 300);
+    TestBed.flushEffects();
+
+    query.set('a');
+    TestBed.flushEffects();
+    query.set('ab');
+    TestBed.flushEffects();
+
+    jasmine.clock().tick(100);
+
+    query.set('abc');
+    TestBed.flushEffects();
+    query.set('abcd');
+    TestBed.flushEffects();
+
+    expect(searchSpy).not.toHaveBeenCalled();
+
+    jasmine.clock().tick(300);
+
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+    expect(searchSpy.calls.mostRecent().returnValue).toBe(
+      `Running search with abcd`
+    );
+  });
+
+  it('should call effect function immediately when immediate flag is true', () => {
+    const query = signal('initial q');
+    const searchSpy = jasmine
+      .createSpy('searchSpy')
+      .and.callFake(() => `Running search with ${query()}`);
+
+    debouncedEffect(() => searchSpy(), 300, { immediate: true });
+    TestBed.flushEffects();
+
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+    expect(searchSpy.calls.mostRecent().returnValue).toBe(
+      `Running search with initial q`
+    );
+  });
+});

--- a/projects/ng-signal-utils/src/lib/debounced-effect/index.ts
+++ b/projects/ng-signal-utils/src/lib/debounced-effect/index.ts
@@ -1,0 +1,58 @@
+import { DestroyRef, effect, inject } from '@angular/core';
+import debounce from 'lodash.debounce';
+
+/**
+ * Creates a debounced effect that limits the frequency of callback execution.
+ *
+ * @param effectFn - The effect function to be debounced
+ * @param wait - The number of milliseconds to wait before invoking the function
+ * @param options - Configuration options for the effect
+ * @returns An effect reference
+ *
+ * @example
+ * // Debounce a search effect with 300ms wait
+ * debouncedEffect(() => {
+ *   performSearch(searchQuery());
+ * }, 300);
+ *
+ * @example
+ * // Immediate effect on first call
+ * debouncedEffect(() => {
+ *   performSearch(searchQuery());
+ * }, 300, { immediate: true });
+ */
+export function debouncedEffect(
+  effectFn: () => any,
+  wait: number,
+  options: {
+    /**
+     * Automatically manage effect lifecycle
+     * @default true
+     */
+    autoDestroy?: boolean;
+    /**
+     * Whether to trigger the function on the leading edge (first call)
+     * instead of the trailing edge
+     * @default true
+     */
+    immediate?: boolean;
+  } = {}
+) {
+  const { autoDestroy = true, immediate = false } = options;
+
+  const debouncedFunction = debounce(() => effectFn(), wait, {
+    leading: immediate,
+    trailing: !immediate,
+  });
+
+  const effectInstance = effect(() => debouncedFunction());
+
+  if (autoDestroy) {
+    const destroyRef = inject(DestroyRef, { optional: true });
+    destroyRef?.onDestroy(() => {
+      effectInstance.destroy();
+    });
+  }
+
+  return effectInstance;
+}

--- a/projects/ng-signal-utils/src/lib/effect-until/index.ts
+++ b/projects/ng-signal-utils/src/lib/effect-until/index.ts
@@ -23,12 +23,12 @@ import { DestroyRef, effect, inject } from '@angular/core';
  * // Disable auto-destroy if needed
  * effectUntil(
  *   () => trackSomeMetrics(),
- *   () => shouldStopTracking,
+ *   () => shouldStopTracking(),
  *   { autoDestroy: false }
  * );
  */
 export function effectUntil(
-  effectFn: () => void,
+  effectFn: () => any,
   predicate: () => boolean,
   options: {
     /**

--- a/projects/ng-signal-utils/src/lib/effect-with-deps/effect-with-deps.spec.ts
+++ b/projects/ng-signal-utils/src/lib/effect-with-deps/effect-with-deps.spec.ts
@@ -1,4 +1,4 @@
-import { computed, Injector, signal } from '@angular/core';
+import { computed, DestroyRef, Injector, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { effectWithDeps as sutOriginal } from '.';
 import { withInjectionContext } from '../../utils/testing/withInjectionContext';
@@ -7,7 +7,9 @@ describe('effectWithDeps', () => {
   let effectWithDeps: typeof sutOriginal;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [DestroyRef],
+    });
     const testInjector = TestBed.inject(Injector);
 
     effectWithDeps = withInjectionContext(testInjector, sutOriginal);

--- a/projects/ng-signal-utils/src/lib/effect-with-deps/index.ts
+++ b/projects/ng-signal-utils/src/lib/effect-with-deps/index.ts
@@ -39,7 +39,7 @@ import {
  */
 export function effectWithDeps<T extends Signal<any>>(
   deps: T[],
-  effectFn: () => void,
+  effectFn: () => any,
   options: {
     /**
      * Automatically manage effect lifecycle


### PR DESCRIPTION
I'm not sure about the addition of lodash. I know this could be done with what's already available in rxjs but I'm making the decision to treat signals and effects as first class citizens and not simple wrappers around the rxjs library. 

I'm not opposed to replacing the lodash.debounce package with something hand rolled in the future